### PR TITLE
Add agent service

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Testing
 Put files to be populated by Ignition in the tree rooted at
 `data/ignition/files/`. Put systemd units in `data/ignition/systemd/units`.
 
+The agent.service file requires SERVICE_BASE_URL and INFRA_ENV_ID to be set.
+The pull secret is also required and is written to /root/.docker/config.json in
+the ISO.
+For now, these are set through environment variables.
+
+```shell
+export PULL_SECRET=$(cat ~/Downloads/pull-secret.txt)
+export SERVICE_BASE_URL=http://10.0.1.10:6000
+export INFRA_ENV_ID=60947297-c9a1-49ac-8119-d9656a244c83
+```
+
 Run the tool using `go run cmd/main.go`.
 
 The output ISO is written to `output/fleeting.iso`.

--- a/data/ignition/files/etc/motd
+++ b/data/ignition/files/etc/motd
@@ -1,0 +1,10 @@
+**  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  ** **  **  **  **  **  **  **
+This is a host being installed by the OpenShift Assisted Installer.
+It will be installed from scratch during the installation.
+
+The primary service is agent.service. To watch its status, run:
+sudo journalctl -u agent.service
+
+To view the agent log, run:
+sudo journalctl TAG=agent
+**  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  ** **  **  **  **  **  **  **

--- a/data/ignition/files/root/assisted.te
+++ b/data/ignition/files/root/assisted.te
@@ -1,0 +1,13 @@
+module assisted 1.0;
+require {
+        type chronyd_t;
+        type container_file_t;
+        type spc_t;
+        class unix_dgram_socket sendto;
+        class dir search;
+        class sock_file write;
+}
+#============= chronyd_t ==============
+allow chronyd_t container_file_t:dir search;
+allow chronyd_t container_file_t:sock_file write;
+allow chronyd_t spc_t:unix_dgram_socket sendto;

--- a/data/ignition/systemd/units/agent.service
+++ b/data/ignition/systemd/units/agent.service
@@ -1,0 +1,24 @@
+[Service]
+Type=simple
+Restart=always
+RestartSec=3
+StartLimitInterval=0
+Environment=HTTP_PROXY=
+Environment=http_proxy=
+Environment=HTTPS_PROXY=
+Environment=https_proxy=
+Environment=NO_PROXY=
+Environment=no_proxy=
+# TODO: If AUTH_TYPE != none, then PULL_SECRET_TOKEN needs to be updated
+# https://github.com/openshift/assisted-service/blob/master/internal/ignition/ignition.go#L1381
+Environment=PULL_SECRET_TOKEN={{.PullSecretToken}}
+TimeoutStartSec=180
+ExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin quay.io/edge-infrastructure/assisted-installer-agent:latest cp /usr/bin/agent /hostbin
+ExecStart=/usr/local/bin/agent --url {{.ServiceBaseURL}} --infra-env-id {{.infraEnvId}} --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true
+
+[Unit]
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target

--- a/data/ignition/systemd/units/selinux.service
+++ b/data/ignition/systemd/units/selinux.service
@@ -1,0 +1,8 @@
+[Service]
+Type=oneshot
+ExecStartPre=checkmodule -M -m -o /root/assisted.mod /root/assisted.te
+ExecStartPre=semodule_package -o /root/assisted.pp -m /root/assisted.mod
+ExecStart=semodule -i /root/assisted.pp
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/imagebuilder/content.go
+++ b/pkg/imagebuilder/content.go
@@ -16,6 +16,36 @@ import (
 )
 
 type ConfigBuilder struct {
+	pullSecret      string
+	serviceBaseURL  string
+	infraEnvID      string
+	pullSecretToken string
+}
+
+func New() *ConfigBuilder {
+	pullSecret := getEnv("PULL_SECRET", "")
+	// TODO: try setting SERVICE_BASE_URL within agent.service
+	serviceBaseURL := getEnv("SERVICE_BASE_URL", "http://127.0.0.1")
+	// TODO: get id either from InfraEnv CR that is included
+	// with tool, or query the id from the REST_API
+	// curl http://SERVICE_BASE_URL/api/assisted-install/v2/infra-envs
+	infraEnvID := getEnv("INFRA_ENV_ID", "infra-env-id-missing")
+	// TODO: needs appropriate value if AUTH_TYPE != none
+	pullSecretToken := getEnv("PULL_SECRET_TOKEN", "")
+
+	return &ConfigBuilder{
+		pullSecret:      pullSecret,
+		serviceBaseURL:  serviceBaseURL,
+		infraEnvID:      infraEnvID,
+		pullSecretToken: pullSecretToken,
+	}
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }
 
 func (c ConfigBuilder) Ignition() ([]byte, error) {
@@ -39,24 +69,26 @@ func (c ConfigBuilder) Ignition() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// pull secret not included in data/ignition/files because embed.FS
 	// does not list directories with name starting with '.'
-	mode := 0420
-	pullSecretText := os.Getenv("PULL_SECRET")
-
-	pullSecret := igntypes.File{
-		Node: igntypes.Node{
-			Path:      "/root/.docker/config.json",
-			Overwrite: ignutil.BoolToPtr(true),
-		},
-		FileEmbedded1: igntypes.FileEmbedded1{
-			Mode: &mode,
-			Contents: igntypes.Resource{
-				Source: ignutil.StrToPtr(dataurl.EncodeBytes([]byte(pullSecretText))),
+	if c.pullSecret != "" {
+		mode := 0420
+		pullSecret := igntypes.File{
+			Node: igntypes.Node{
+				Path:      "/root/.docker/config.json",
+				Overwrite: ignutil.BoolToPtr(true),
 			},
-		},
+			FileEmbedded1: igntypes.FileEmbedded1{
+				Mode: &mode,
+				Contents: igntypes.Resource{
+					Source: ignutil.StrToPtr(dataurl.EncodeBytes([]byte(c.pullSecret))),
+				},
+			},
+		}
+		files = append(files, pullSecret)
 	}
-	files = append(files, pullSecret)
+
 	config.Storage.Files = files
 
 	config.Systemd.Units, err = c.getUnits()
@@ -140,7 +172,7 @@ func (c ConfigBuilder) getUnits() ([]igntypes.Unit, error) {
 			return units, fmt.Errorf("Failed to read unit %s: %w", e.Name(), err)
 		}
 
-		templated, err := templateString(e.Name(), string(contents))
+		templated, err := c.templateString(e.Name(), string(contents))
 		if err != nil {
 			return units, err
 		}
@@ -156,16 +188,11 @@ func (c ConfigBuilder) getUnits() ([]igntypes.Unit, error) {
 	return units, nil
 }
 
-func templateString(name string, text string) (string, error) {
+func (c ConfigBuilder) templateString(name string, text string) (string, error) {
 	params := map[string]interface{}{
-		// TODO: try setting SERVICE_BASE_URL within agent.service
-		"ServiceBaseURL": os.Getenv("SERVICE_BASE_URL"),
-		// TODO: get id either from InfraEnv CR that is included
-		// with tool, or query the id from the REST_API
-		// curl http://SERVICE_BASE_URL/api/assisted-install/v2/infra-envs
-		"infraEnvId": os.Getenv("INFRA_ENV_ID"),
-		// TODO: needs appropriate value if AUTH_TYPE != none
-		"PullSecretToken": os.Getenv("PULL_SECRET_TOKEN"),
+		"ServiceBaseURL":  c.serviceBaseURL,
+		"infraEnvId":      c.infraEnvID,
+		"PullSecretToken": c.pullSecretToken,
 	}
 
 	tmpl, err := template.New(name).Parse(string(text))

--- a/pkg/imagebuilder/content.go
+++ b/pkg/imagebuilder/content.go
@@ -1,10 +1,12 @@
 package imagebuilder
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path"
+	template "text/template"
 
 	ignutil "github.com/coreos/ignition/v2/config/util"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
@@ -33,10 +35,29 @@ func (c ConfigBuilder) Ignition() ([]byte, error) {
 		},
 	}
 
-	config.Storage.Files, err = c.getFiles()
+	files, err := c.getFiles()
 	if err != nil {
 		return nil, err
 	}
+	// pull secret not included in data/ignition/files because embed.FS
+	// does not list directories with name starting with '.'
+	mode := 0420
+	pullSecretText := os.Getenv("PULL_SECRET")
+
+	pullSecret := igntypes.File{
+		Node: igntypes.Node{
+			Path:      "/root/.docker/config.json",
+			Overwrite: ignutil.BoolToPtr(true),
+		},
+		FileEmbedded1: igntypes.FileEmbedded1{
+			Mode: &mode,
+			Contents: igntypes.Resource{
+				Source: ignutil.StrToPtr(dataurl.EncodeBytes([]byte(pullSecretText))),
+			},
+		},
+	}
+	files = append(files, pullSecret)
+	config.Storage.Files = files
 
 	config.Systemd.Units, err = c.getUnits()
 	if err != nil {
@@ -119,13 +140,42 @@ func (c ConfigBuilder) getUnits() ([]igntypes.Unit, error) {
 			return units, fmt.Errorf("Failed to read unit %s: %w", e.Name(), err)
 		}
 
+		templated, err := templateString(e.Name(), string(contents))
+		if err != nil {
+			return units, err
+		}
+
 		unit := igntypes.Unit{
 			Name:     e.Name(),
 			Enabled:  ignutil.BoolToPtr(true),
-			Contents: ignutil.StrToPtr(string(contents)),
+			Contents: ignutil.StrToPtr(string(templated)),
 		}
 		units = append(units, unit)
 	}
 
 	return units, nil
+}
+
+func templateString(name string, text string) (string, error) {
+	params := map[string]interface{}{
+		// TODO: try setting SERVICE_BASE_URL within agent.service
+		"ServiceBaseURL": os.Getenv("SERVICE_BASE_URL"),
+		// TODO: get id either from InfraEnv CR that is included
+		// with tool, or query the id from the REST_API
+		// curl http://SERVICE_BASE_URL/api/assisted-install/v2/infra-envs
+		"infraEnvId": os.Getenv("INFRA_ENV_ID"),
+		// TODO: needs appropriate value if AUTH_TYPE != none
+		"PullSecretToken": os.Getenv("PULL_SECRET_TOKEN"),
+	}
+
+	tmpl, err := template.New(name).Parse(string(text))
+	if err != nil {
+		return "", err
+	}
+	buf := &bytes.Buffer{}
+	if err = tmpl.Execute(buf, params); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }

--- a/pkg/imagebuilder/embed_ignition.go
+++ b/pkg/imagebuilder/embed_ignition.go
@@ -12,7 +12,8 @@ const (
 )
 
 func BuildImage(baseImage string) error {
-	ignition, err := ConfigBuilder{}.Ignition()
+	configBuilder := New()
+	ignition, err := configBuilder.Ignition()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some environment variables are used as placeholders for values
that can be determined elsewhere when assisted-service, agent,
and the CRDs required to install the cluster are integrated.