### PR TITLE
Run assisted-service only on pre-identified node0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .PHONY: iso
-iso:
-	go run cmd/main.go
+
+clean:
+	rm -rf bin
+	rm -rf output
+
+iso: clean
+	go run cmd/main.go -node-zero-ip 192.168.122.2
 
 test: lint shellcheck
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,43 @@ The output ISO is written to `output/fleeting.iso`.
 
 Boot the ISO in a VM with at least 4096MiB of RAM. No storage is required.
 The assisted-service UI is available on port 8080.
+
+Node0
+-------
+
+To run the assisted service only on a pre-determined node a.k.a. node0, currently we have hardcoded a static IP 192.168.122.2. 
+A systemd service named `node-zero.service` looks for the static IP and if the current node's IP matches with it then only the `assisted-service.service` systemd service is startred. The `assisted-service.service` is responsible for running the assisted service.
+
+To set the static ip in libvirt:
+1. Edit the default network
+```
+virsh net-edit default
+```
+2. Add `dns` and `host mac` for node0
+
+```
+<network>
+  <name>default</name>
+  <uuid>2467ce0f-aff2-4031-b0be-3e40fca96421</uuid>
+  <forward mode='nat'/>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <mac address='52:54:00:bf:2b:d4'/>
+  <dns>
+    <host ip='192.168.122.2'>
+      <hostname>node0</hostname>
+    </host>
+  </dns>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+      <host mac='52:54:00:aa:aa:aa' ip='192.168.122.2'/>
+    </dhcp>
+  </ip>
+</network>
+```
+3. Destroy and start network
+```
+sudo virsh net-destroy default
+sudo virsh net-start default
+```
+

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,17 +1,28 @@
 package main
 
 import (
+	"flag"
+	"os"
+
 	"github.com/openshift-agent-team/fleeting/pkg/imagebuilder"
 	"github.com/openshift-agent-team/fleeting/pkg/isosource"
 )
 
 func main() {
+	nodeZeroIP := flag.String("node-zero-ip", "", "IP of the node to run OpenShift Assisted Installation Service on. (Required)")
+	flag.Parse()
+
+	if *nodeZeroIP == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
 	baseImage, err := isosource.EnsureIso()
 	if err != nil {
 		panic(err)
 	}
 
-	err = imagebuilder.BuildImage(baseImage)
+	err = imagebuilder.BuildImage(baseImage, *nodeZeroIP)
 	if err != nil {
 		panic(err)
 	}

--- a/data/ignition/files/usr/local/bin/common.sh
+++ b/data/ignition/files/usr/local/bin/common.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+get_host() {
+    local default_gateway
+    local host_ip
+
+    default_gateway=$(ip -j route show default | jq -r '.[0].gateway')
+    host_ip=$(ip -j route get "${default_gateway}" | jq -r '.[0].prefsrc')
+
+    local host_fmt="%s"
+    if [[ ${host_ip} =~ : ]]; then
+        host_fmt="[%s]"
+    fi
+
+    # shellcheck disable=SC2059
+    printf "${host_fmt}" "${host_ip}"
+}

--- a/data/ignition/files/usr/local/bin/set-node-zero.sh
+++ b/data/ignition/files/usr/local/bin/set-node-zero.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source common.sh
+
+HOST=$(get_host)
+echo Using hostname ${HOST} 1>&2
+
+if [[ ${HOST} == {{.NodeZeroIP}} ]] ;then
+   mkdir -p /etc/assisted-service && cd /etc/assisted-service && touch node0
+   echo "This host is identified and set as node zero to run OpenShift Assisted Installer Service." > /etc/assisted-service/node0
+   echo "Created file /etc/assisted-service/node0"
+fi

--- a/data/ignition/files/usr/local/share/assisted-service/configmap.yml
+++ b/data/ignition/files/usr/local/share/assisted-service/configmap.yml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: config
 data:
-  ASSISTED_SERVICE_HOST: 127.0.0.1:8090
+  ASSISTED_SERVICE_HOST: {{.NodeZeroIP}}:8090
   ASSISTED_SERVICE_SCHEME: http
   AUTH_TYPE: none
   DB_HOST: 127.0.0.1
@@ -16,7 +16,7 @@ data:
   DUMMY_IGNITION: "false"
   ENABLE_SINGLE_NODE_DNSMASQ: "true"
   HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]'
-  IMAGE_SERVICE_BASE_URL: http://127.0.0.1:8888
+  IMAGE_SERVICE_BASE_URL: http://{{.NodeZeroIP}}:8888
   IPV6_SUPPORT: "true"
   LISTEN_PORT: "8888"
   NTP_DEFAULT_SERVER: ""
@@ -26,5 +26,5 @@ data:
   POSTGRESQL_USER: admin
   PUBLIC_CONTAINER_REGISTRIES: 'quay.io'
   RELEASE_IMAGES: '[{"openshift_version":"4.10","cpu_architecture":"x86_64","url":"quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64","version":"4.10.0-rc.1"}]'
-  SERVICE_BASE_URL: http://127.0.0.1:8090
+  SERVICE_BASE_URL: http://{{.NodeZeroIP}}:8090
   STORAGE: filesystem

--- a/data/ignition/systemd/units/assisted-service.service
+++ b/data/ignition/systemd/units/assisted-service.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=OpenShift Assisted Installation Service
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target node-zero.service
+After=network-online.target node-zero.service
+ConditionPathExists=/etc/assisted-service/node0
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/data/ignition/systemd/units/node-zero.service
+++ b/data/ignition/systemd/units/node-zero.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Identify node zero to run OpenShift Assisted Installation Service on
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/set-node-zero.sh
+ExecStartPost=/bin/sleep 5
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/imagebuilder/content.go
+++ b/pkg/imagebuilder/content.go
@@ -21,12 +21,13 @@ type ConfigBuilder struct {
 	serviceBaseURL  string
 	infraEnvID      string
 	pullSecretToken string
+	nodeZeroIP      string
 }
 
-func New() *ConfigBuilder {
+func New(nodeZeroIP string) *ConfigBuilder {
 	pullSecret := getEnv("PULL_SECRET", "")
 	// TODO: try setting SERVICE_BASE_URL within agent.service
-	serviceBaseURL := getEnv("SERVICE_BASE_URL", "http://127.0.0.1")
+	serviceBaseURL := getEnv("SERVICE_BASE_URL", "http://"+nodeZeroIP+":8090")
 	// TODO: get id either from InfraEnv CR that is included
 	// with tool, or query the id from the REST_API
 	// curl http://SERVICE_BASE_URL/api/assisted-install/v2/infra-envs
@@ -39,6 +40,7 @@ func New() *ConfigBuilder {
 		serviceBaseURL:  serviceBaseURL,
 		infraEnvID:      infraEnvID,
 		pullSecretToken: pullSecretToken,
+		nodeZeroIP:      nodeZeroIP,
 	}
 }
 
@@ -120,7 +122,7 @@ func (c ConfigBuilder) getFiles() ([]igntypes.File, error) {
 	readDir = func(dirPath string, files []igntypes.File) ([]igntypes.File, error) {
 		entries, err := data.IgnitionData.ReadDir(path.Join("ignition/files", dirPath))
 		if err != nil {
-			return files, fmt.Errorf("Failed to open file dir \"%s\": %w", dirPath, err)
+			return files, fmt.Errorf("failed to open file dir \"%s\": %w", dirPath, err)
 		}
 		for _, e := range entries {
 			fullPath := path.Join(dirPath, e.Name())
@@ -132,8 +134,13 @@ func (c ConfigBuilder) getFiles() ([]igntypes.File, error) {
 			} else {
 				contents, err := data.IgnitionData.ReadFile(path.Join("ignition/files", fullPath))
 				if err != nil {
-					return files, fmt.Errorf("Failed to read file %s: %w", fullPath, err)
+					return files, fmt.Errorf("failed to read file %s: %w", fullPath, err)
 				}
+				templated, err := c.templateString(e.Name(), string(contents))
+				if err != nil {
+					return files, err
+				}
+
 				mode := 0600
 				if _, dirName := path.Split(dirPath); dirName == "bin" || dirName == "dispatcher.d" {
 					mode = 0555
@@ -146,7 +153,7 @@ func (c ConfigBuilder) getFiles() ([]igntypes.File, error) {
 					FileEmbedded1: igntypes.FileEmbedded1{
 						Mode: &mode,
 						Contents: igntypes.Resource{
-							Source: ignutil.StrToPtr(dataurl.EncodeBytes(contents)),
+							Source: ignutil.StrToPtr(dataurl.EncodeBytes([]byte(templated))),
 						},
 					},
 				}
@@ -165,13 +172,13 @@ func (c ConfigBuilder) getUnits() ([]igntypes.Unit, error) {
 
 	entries, err := data.IgnitionData.ReadDir(basePath)
 	if err != nil {
-		return units, fmt.Errorf("Failed to read systemd units: %w", err)
+		return units, fmt.Errorf("failed to read systemd units: %w", err)
 	}
 
 	for _, e := range entries {
 		contents, err := data.IgnitionData.ReadFile(path.Join(basePath, e.Name()))
 		if err != nil {
-			return units, fmt.Errorf("Failed to read unit %s: %w", e.Name(), err)
+			return units, fmt.Errorf("failed to read unit %s: %w", e.Name(), err)
 		}
 
 		templated, err := c.templateString(e.Name(), string(contents))
@@ -195,6 +202,7 @@ func (c ConfigBuilder) templateString(name string, text string) (string, error) 
 		"ServiceBaseURL":  c.serviceBaseURL,
 		"infraEnvId":      c.infraEnvID,
 		"PullSecretToken": c.pullSecretToken,
+		"NodeZeroIP":      c.nodeZeroIP,
 	}
 
 	tmpl, err := template.New(name).Parse(string(text))

--- a/pkg/imagebuilder/embed_ignition.go
+++ b/pkg/imagebuilder/embed_ignition.go
@@ -13,8 +13,8 @@ const (
 
 // BuildImage builds an ISO with ignition content from a base image, and writes
 // the result to disk.
-func BuildImage(baseImage string) error {
-	configBuilder := New()
+func BuildImage(baseImage string, nodeZeroIP string) error {
+	configBuilder := New(nodeZeroIP)
 	ignition, err := configBuilder.Ignition()
 	if err != nil {
 		return err


### PR DESCRIPTION
Run the assisted service only on node0.

Run `make iso` which creates an ISO with a default node zero ip `192.168.122.2`. 

To set a different IP for node zero, `go run cmd/main.go -node-zero-ip 192.168.122.4`

A systemd service  `node-zero.service` looks for the node zero IP and if the current node's IP matches with it then only the `assisted-service.service` systemd service is startred. The `assisted-service.service` is responsible for running the assisted service.

Ref: https://issues.redhat.com/browse/AGENT-33