### PR TITLE
Rename assisted-installer pod to assisted-service

### DIFF
--- a/data/ignition/files/usr/local/share/assisted-service/pod.yml
+++ b/data/ignition/files/usr/local/share/assisted-service/pod.yml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: assisted-installer
-  name: assisted-installer
+    app: assisted-service
+  name: assisted-service
 spec:
   containers:
   - args:

--- a/data/ignition/systemd/units/assisted-service.service
+++ b/data/ignition/systemd/units/assisted-service.service
@@ -7,8 +7,8 @@ ConditionPathExists=/etc/assisted-service/node0
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 ExecStart=/usr/local/bin/start-assisted-service.sh
-ExecStop=/bin/podman pod stop --ignore assisted-installer -t 10
-ExecStopPost=/bin/podman pod rm --ignore assisted-installer
+ExecStop=/bin/podman pod stop --ignore assisted-service -t 10
+ExecStopPost=/bin/podman pod rm --ignore assisted-service
 
 Restart=on-failure
 KillMode=none


### PR DESCRIPTION
When cluster installation starts, another pod, also named
assisted-installer will run on the hosts. So let's change
our pod's name to assisted-service.