### PR TITLE
AGENT-43 Fetch infra-env-id before host registration

### DIFF
--- a/data/ignition/files/usr/local/bin/start-agent.sh
+++ b/data/ignition/files/usr/local/bin/start-agent.sh
@@ -2,16 +2,16 @@
 
 source common.sh
 
-echo "Waiting for infra-env-id to be available"
+>&2 echo "Waiting for infra-env-id to be available"
 INFRA_ENV_ID=""
 until [[ $INFRA_ENV_ID != "" && $INFRA_ENV_ID != "null" ]]; do
     sleep 5
-    printf 'Querying assisted-service for infra-env-id...'
-    INFRA_ENV_ID=$(curl {{.ServiceBaseURL}}/api/assisted-install/v2/infra-envs | jq .[0].id)
+    >&2 echo "Querying assisted-service for infra-env-id..."
+    INFRA_ENV_ID=$(curl '{{.ServiceBaseURL}}/api/assisted-install/v2/infra-envs' | jq .[0].id)
 done
 # trim quotes
 INFRA_ENV_ID=${INFRA_ENV_ID//\"}
 echo "Fetched infra-env-id and found: $INFRA_ENV_ID"
 
 # use infra-env-id to have agent register this host with assisted-service
-/usr/local/bin/agent --url {{.ServiceBaseURL}} --infra-env-id $INFRA_ENV_ID --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true
+exec /usr/local/bin/agent --url '{{.ServiceBaseURL}}' --infra-env-id "$INFRA_ENV_ID" --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true

--- a/data/ignition/files/usr/local/bin/start-agent.sh
+++ b/data/ignition/files/usr/local/bin/start-agent.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source common.sh
+
+echo "Waiting for infra-env-id to be available"
+INFRA_ENV_ID=""
+until [[ $INFRA_ENV_ID != "" && $INFRA_ENV_ID != "null" ]]; do
+    sleep 5
+    printf 'Querying assisted-service for infra-env-id...'
+    INFRA_ENV_ID=$(curl {{.ServiceBaseURL}}/api/assisted-install/v2/infra-envs | jq .[0].id)
+done
+# trim quotes
+INFRA_ENV_ID=${INFRA_ENV_ID//\"}
+echo "Fetched infra-env-id and found: $INFRA_ENV_ID"
+
+# use infra-env-id to have agent register this host with assisted-service
+/usr/local/bin/agent --url {{.ServiceBaseURL}} --infra-env-id $INFRA_ENV_ID --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true

--- a/data/ignition/systemd/units/agent.service
+++ b/data/ignition/systemd/units/agent.service
@@ -12,10 +12,9 @@ Environment=no_proxy=
 # TODO: If AUTH_TYPE != none, then PULL_SECRET_TOKEN needs to be updated
 # https://github.com/openshift/assisted-service/blob/master/internal/ignition/ignition.go#L1381
 Environment=PULL_SECRET_TOKEN={{.PullSecretToken}}
-TimeoutStartSec=180
+TimeoutStartSec=3000
 ExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin quay.io/edge-infrastructure/assisted-installer-agent:latest cp /usr/bin/agent /hostbin
-ExecStart=/usr/local/bin/agent --url {{.ServiceBaseURL}} --infra-env-id {{.infraEnvId}} --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true
-
+ExecStart=/usr/local/bin/start-agent.sh
 [Unit]
 Wants=network-online.target
 After=network-online.target


### PR DESCRIPTION
The agent is baked into the ISO without knowing which infra-env-id
it should use when it registers a host with assisted-service.

Before starting the agent, a shell script continously calls
the assisted-service REST-API waiting for an infra-env to appear.
An infra-env should have been created on node0 after assisted-service
has started up.

When the REST-API list call returns an infra-env, the script
extracts the infra-env-id and passes the id to the agent.