### PR TITLE
NO-ISSUE Increase assisted-service start timeout

### DIFF
--- a/data/ignition/systemd/units/assisted-service.service
+++ b/data/ignition/systemd/units/assisted-service.service
@@ -6,6 +6,7 @@ ConditionPathExists=/etc/assisted-service/node0
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
+TimeoutStartSec=300
 ExecStart=/usr/local/bin/start-assisted-service.sh
 ExecStop=/bin/podman pod stop --ignore assisted-service -t 10
 ExecStopPost=/bin/podman pod rm --ignore assisted-service


### PR DESCRIPTION
Default timeout of 90s is not long enough on my network and laptop
for assisted-service images to be pulled.

Increasing timeout to 300s.