### PR TITLE
Exit on manifest file errors

### DIFF
--- a/pkg/manifests/clusterdeployment.go
+++ b/pkg/manifests/clusterdeployment.go
@@ -10,43 +10,36 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/yaml"
 )
 
 func GetPullSecret() string {
-	secretData, err := os.ReadFile("./manifests/pull-secret.yaml")
-	if err != nil {
-		fmt.Errorf("Error reading pull secret: %w", err)
-	}
 	var secret corev1.Secret
-	if err := yaml.Unmarshal(secretData, &secret); err != nil {
-		fmt.Errorf("Error unmarshalling pull secret: %w", err)
+	if err := GetFileData("pull-secret.yaml", &secret); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
+
 	pullSecret := secret.StringData[".dockerconfigjson"]
 	return pullSecret
 }
 
 func getClusterDeployment() hivev1.ClusterDeployment {
-	cdData, err := os.ReadFile("./manifests/cluster-deployment.yaml")
-	if err != nil {
-		fmt.Errorf("Error reading cluster deployment CR: %w", err)
-	}
 	var cd hivev1.ClusterDeployment
-	if err := yaml.Unmarshal(cdData, &cd); err != nil {
-		fmt.Errorf("Error unmarshalling cluster deployment CR: %w", err)
+	if err := GetFileData("cluster-deployment.yaml", &cd); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
+
 	return cd
 }
 
 func getAgentClusterInstall() hiveext.AgentClusterInstall {
-	aciData, err := os.ReadFile("./manifests/agent-cluster-install.yaml")
-	if err != nil {
-		fmt.Errorf("Error reading AgentClusterInstall CR: %w", err)
-	}
 	var aci hiveext.AgentClusterInstall
-	if err := yaml.Unmarshal(aciData, &aci); err != nil {
-		fmt.Errorf("Error unmarshalling AgentClusterInstall CR: %w", err)
+	if err := GetFileData("agent-cluster-install.yaml", &aci); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
+
 	return aci
 }
 

--- a/pkg/manifests/infraenv.go
+++ b/pkg/manifests/infraenv.go
@@ -9,18 +9,15 @@ import (
 	"github.com/go-openapi/swag"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/models"
-	"sigs.k8s.io/yaml"
 )
 
 func getInfraEnv() aiv1beta1.InfraEnv {
-	infraEnvData, err := os.ReadFile("./manifests/infraenv.yaml")
-	if err != nil {
-		fmt.Errorf("Error reading pull secret: %w", err)
-	}
 	var infraEnv aiv1beta1.InfraEnv
-	if err := yaml.Unmarshal(infraEnvData, &infraEnv); err != nil {
-		fmt.Errorf("Error unmarshalling pull secret: %w", err)
+	if err := GetFileData("infraenv.yaml", &infraEnv); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
+
 	return infraEnv
 }
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1,0 +1,24 @@
+package manifests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Read a Yaml file and unmarshal the contents
+func GetFileData(fileName string, output interface{}) error {
+
+	path := filepath.Join("./manifests", fileName)
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		err = fmt.Errorf("Error reading file %s: %w", path, err)
+	} else if err = yaml.Unmarshal(contents, output); err != nil {
+		err = fmt.Errorf("Error unmarshalling contents of %s: %w", path, err)
+	}
+
+	return err
+}


### PR DESCRIPTION
Use common function to read and unmarshal files. Exit if errors detected.