### PR TITLE
AGENT-34: Mount agent host-id in assisted-service container

### DIFF
--- a/data/ignition/files/usr/local/share/assisted-service/assisted-service.env
+++ b/data/ignition/files/usr/local/share/assisted-service/assisted-service.env
@@ -8,6 +8,7 @@ DEPLOY_TARGET=onprem
 DISK_ENCRYPTION_SUPPORT=true
 DUMMY_IGNITION=false
 ENABLE_SINGLE_NODE_DNSMASQ=true
+EPHEMERAL_INSTALLER=true
 HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]
 IMAGE_SERVICE_BASE_URL=http://{{.NodeZeroIP}}:8888
 IPV6_SUPPORT=true

--- a/data/ignition/systemd/units/assisted-service-pod.service
+++ b/data/ignition/systemd/units/assisted-service-pod.service
@@ -5,12 +5,13 @@ After=network-online.target node-zero.service
 ConditionPathExists=/etc/assisted-service/node0
 RequiresMountsFor=
 Requires=assisted-service-db.service assisted-service.service assisted-service-ui.service
-Before=assisted-service-db.service assisted-service.service assisted-service-ui.service
+Before=agent.service assisted-service-db.service assisted-service.service assisted-service-ui.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
+ExecStartPre=/bin/mkdir -p %t/assisted-agent
 ExecStartPre=/bin/rm -f %t/%n.pid %t/%N.pod-id
 ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/%n.pid --pod-id-file %t/%N.pod-id -n assisted-service --publish=8090:8090 --publish=8080:8080 --publish=8888:8888
 ExecStart=/usr/bin/podman pod start --pod-id-file=%t/%N.pod-id

--- a/data/ignition/systemd/units/assisted-service.service
+++ b/data/ignition/systemd/units/assisted-service.service
@@ -11,7 +11,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=300
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env quay.io/edge-infrastructure/assisted-service:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service -v %t/assisted-agent:/var/run/assisted-agent:z --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env quay.io/edge-infrastructure/assisted-service:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify


### PR DESCRIPTION
Ensure that assisted-service can determine the Host ID of the local
agent, by creating the directory /var/run/assisted-agent for the agent
to write the ID into, and mounting that directory into the
assisted-service container.

/hold
Depends on:

* https://github.com/openshift/assisted-installer-agent/pull/314
* https://github.com/openshift/assisted-service/pull/3589
* #13