### PR TITLE
AGENT-48: Add NMStateConfig to InfraEnvCreateParams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openshift/assisted-image-service v0.0.0-20220307202600-054a1afa8d28
 	github.com/openshift/assisted-service v1.0.10-0.20220116113517-db25501e204a
 	github.com/openshift/hive/apis v0.0.0-20210506000654-5c038fb05190
+	github.com/pkg/errors v0.9.1
 	github.com/thoas/go-funk v0.9.1
 	github.com/vincent-petithory/dataurl v1.0.0
 	k8s.io/api v0.21.1

--- a/pkg/imagebuilder/content.go
+++ b/pkg/imagebuilder/content.go
@@ -41,7 +41,11 @@ func New(nodeZeroIP string) *ConfigBuilder {
 		fmt.Errorf("Error marshalling cluster params into json: %w", err)
 	}
 
-	infraEnvParams := manifests.CreateInfraEnvParams()
+	infraEnvParams, err := manifests.CreateInfraEnvParams()
+	if err != nil {
+		fmt.Errorf("Error building infra env params: %w", err)
+	}
+
 	infraEnvJSON, err := json.Marshal(infraEnvParams)
 	if err != nil {
 		fmt.Errorf("Error marshal infra env params into json: %w", err)

--- a/pkg/manifests/infraenv.go
+++ b/pkg/manifests/infraenv.go
@@ -24,7 +24,7 @@ func getInfraEnv() aiv1beta1.InfraEnv {
 // createInfraEnvParams body was copied from
 // https://github.com/openshift/assisted-service/blob/5d4d836747862f43fa2ec882e5871648bd12c780/internal/controller/controllers/infraenv_controller.go#L339
 // TODO: Refactor infraenv_controller to have a CreateInfraEnvParams function that can be used in controller and here.
-func CreateInfraEnvParams() *models.InfraEnvCreateParams {
+func CreateInfraEnvParams() (*models.InfraEnvCreateParams, error) {
 	infraEnv := getInfraEnv()
 	// TODO: Have single source for image version and cpu arch
 	releaseImageVersion := "4.10.0-rc.1"
@@ -58,5 +58,15 @@ func CreateInfraEnvParams() *models.InfraEnvCreateParams {
 	createParams.ClusterID = &tempClusterID
 	createParams.OpenshiftVersion = &releaseImageVersion
 
-	return createParams
+	staticNetworkConfig, err := ProcessNMStateConfig(infraEnv)
+	if err != nil {
+		return nil, err
+	}
+	if len(staticNetworkConfig) > 0 {
+		// TODO: Use logging
+		// fmt.Printf("the amount of nmStateConfigs included in the image is: %d", len(staticNetworkConfig))
+		createParams.StaticNetworkConfig = staticNetworkConfig
+	}
+
+	return createParams, nil
 }

--- a/pkg/manifests/nmstateconfig.go
+++ b/pkg/manifests/nmstateconfig.go
@@ -1,0 +1,68 @@
+package manifests
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+)
+
+func getNMStateConfig() aiv1beta1.NMStateConfig {
+	var nmStateConfig aiv1beta1.NMStateConfig
+	if err := GetFileData("nmstateconfig.yaml", &nmStateConfig); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	return nmStateConfig
+}
+
+func validateNMStateConfigAndInfraEnv(nmStateConfig aiv1beta1.NMStateConfig, infraEnv aiv1beta1.InfraEnv) error {
+	if len(nmStateConfig.ObjectMeta.Labels) == 0 {
+		return errors.Errorf("NMStateConfig does not have any labels set")
+	}
+
+	if len(infraEnv.Spec.NMStateConfigLabelSelector.MatchLabels) == 0 {
+		return errors.Errorf("Infra env does not have any labels set with NMStateConfigLabelSelector.MatchLabels")
+	}
+
+	if !reflect.DeepEqual(infraEnv.Spec.NMStateConfigLabelSelector.MatchLabels, nmStateConfig.ObjectMeta.Labels) {
+		return errors.Errorf("Infra env and NMStateConfig labels do not match")
+	}
+
+	return nil
+}
+
+func buildMacInterfaceMap(nmStateConfig aiv1beta1.NMStateConfig) models.MacInterfaceMap {
+	macInterfaceMap := make(models.MacInterfaceMap, 0, len(nmStateConfig.Spec.Interfaces))
+	for _, cfg := range nmStateConfig.Spec.Interfaces {
+		// ToDo: Use logging
+		// fmt.Println("adding MAC interface map to host static network config - Name: %s, MacAddress: %s ,",
+		// 	cfg.Name, cfg.MacAddress)
+		macInterfaceMap = append(macInterfaceMap, &models.MacInterfaceMapItems0{
+			MacAddress:     cfg.MacAddress,
+			LogicalNicName: cfg.Name,
+		})
+	}
+	return macInterfaceMap
+}
+
+func ProcessNMStateConfig(infraEnv aiv1beta1.InfraEnv) ([]*models.HostStaticNetworkConfig, error) {
+
+	nmStateConfig := getNMStateConfig()
+
+	err := validateNMStateConfigAndInfraEnv(nmStateConfig, infraEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	var staticNetworkConfig []*models.HostStaticNetworkConfig
+	staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
+		MacInterfaceMap: buildMacInterfaceMap(nmStateConfig),
+		NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
+	})
+	return staticNetworkConfig, nil
+}


### PR DESCRIPTION
Add NMStateConfig to InfraEnvCreateParams. Also, validate the labels from InfraEnv with NMStateConfig labels.

Ref: https://issues.redhat.com/browse/AGENT-48