### PR TITLE
AGENT-34: Set BOOTSTRAP_HOST_MAC in assisted-service environment

### DIFF
--- a/data/ignition/files/usr/local/bin/set-node-zero.sh
+++ b/data/ignition/files/usr/local/bin/set-node-zero.sh
@@ -6,7 +6,16 @@ HOST=$(get_host)
 echo Using hostname ${HOST} 1>&2
 
 if [[ ${HOST} == {{.NodeZeroIP}} ]] ;then
-   mkdir -p /etc/assisted-service && cd /etc/assisted-service && touch node0
-   echo "This host is identified and set as node zero to run OpenShift Assisted Installer Service." > /etc/assisted-service/node0
-   echo "Created file /etc/assisted-service/node0"
+
+    NODE0_PATH=/etc/assisted-service/node0
+    mkdir -p "$(dirname "${NODE0_PATH}")"
+
+    NODE_ZERO_MAC=$(ip -j address | jq -r '.[] | select(.addr_info | map(select(.local == "{{.NodeZeroIP}}")) | any).address')
+    echo "MAC Address for Node 0: ${NODE_ZERO_MAC}"
+
+    cat >"${NODE0_PATH}" <<EOF
+BOOTSTRAP_HOST_MAC=${NODE_ZERO_MAC}
+EOF
+
+    echo "Created file ${NODE0_PATH}"
 fi

--- a/data/ignition/systemd/units/assisted-service.service
+++ b/data/ignition/systemd/units/assisted-service.service
@@ -11,7 +11,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=300
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env quay.io/edge-infrastructure/assisted-service:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env --env-file=/etc/assisted-service/node0 quay.io/edge-infrastructure/assisted-service:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify


### PR DESCRIPTION
Setting the BOOTSTRAP_HOST_MAC environment variable notifies
assisted-service of a MAC address of Node Zero so that it will be set
as the bootstrap host.

We choose the MAC address of interface that the service IP is on, as
that is the most likely to be unique.

To pass the environment variable to assisted-service, we turn the node0
file used to trigger starting the service into an environment file.

/hold
Depends on openshift/assisted-service#3627