### PR TITLE
AGENT-119: Read in multiple NMStateConfig definitions from one yaml file

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1,11 +1,14 @@
 package manifests
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/pkg/errors"
+	"io"
 	"os"
 	"path/filepath"
 
-	"sigs.k8s.io/yaml"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Read a Yaml file and unmarshal the contents
@@ -21,4 +24,41 @@ func GetFileData(fileName string, output interface{}) error {
 	}
 
 	return err
+}
+
+type DecodeFormat interface {
+	NewDecodedYaml(decoder *yaml.YAMLToJSONDecoder) (interface{}, error)
+}
+
+// Read a YAML file containing multiple YAML definitions of the same format
+// Each specific format must be of type DecodeFormat
+func GetFileMultipleYamls(filename string, decoder DecodeFormat) ([]interface{}, error) {
+
+	// TODO - this location must be defined by user input via cobra flags
+	path := filepath.Join("./manifests", filename)
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		err = fmt.Errorf("Error reading file %s: %w", path, err)
+		return nil, err
+	}
+
+	r := bytes.NewReader(contents)
+	dec := yaml.NewYAMLToJSONDecoder(r)
+
+	var outputList []interface{}
+	for {
+		decodedData, err := decoder.NewDecodedYaml(dec)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			err = fmt.Errorf("Error reading multiple yamls in file %s: %w", path, err)
+			return nil, err
+		}
+
+		outputList = append(outputList, decodedData)
+	}
+
+	return outputList, nil
 }


### PR DESCRIPTION
Provides the ability to set static IPs on all hosts. This uses the k8s/apimachinery yaml package as it provides a YAMLtoJSON decoder.

Can be tested with https://github.com/openshift-metal3/dev-scripts/pull/1380, set FLEETING_STATIC_IP_NODE0_ONLY=false.