### PR TITLE
AGENT-66: Use logging

### DIFF
--- a/pkg/imagebuilder/content.go
+++ b/pkg/imagebuilder/content.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift-agent-team/fleeting/pkg/manifests"
 
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 )
 
 const NMCONNECTIONS_DIR = "/etc/assisted/network"
@@ -47,17 +48,17 @@ func New() *ConfigBuilder {
 	clusterParams := manifests.CreateClusterParams()
 	clusterJSON, err := json.Marshal(clusterParams)
 	if err != nil {
-		fmt.Errorf("Error marshalling cluster params into json: %w", err)
+		logrus.Errorf("Error marshalling cluster params into json: %w", err)
 	}
 
 	infraEnvParams, err := manifests.CreateInfraEnvParams()
 	if err != nil {
-		fmt.Errorf("Error building infra env params: %w", err)
+		logrus.Errorf("Error building infra env params: %w", err)
 	}
 
 	infraEnvJSON, err := json.Marshal(infraEnvParams)
 	if err != nil {
-		fmt.Errorf("Error marshal infra env params into json: %w", err)
+		logrus.Errorf("Error marshal infra env params into json: %w", err)
 	}
 
 	aci := manifests.GetAgentClusterInstall()

--- a/pkg/manifests/clusterdeployment.go
+++ b/pkg/manifests/clusterdeployment.go
@@ -1,13 +1,13 @@
 package manifests
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/go-openapi/swag"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -15,7 +15,7 @@ import (
 func GetPullSecret() string {
 	var secret corev1.Secret
 	if err := GetFileData("pull-secret.yaml", &secret); err != nil {
-		fmt.Println(err.Error())
+		logrus.Println(err.Error())
 		os.Exit(1)
 	}
 
@@ -26,7 +26,7 @@ func GetPullSecret() string {
 func getClusterDeployment() hivev1.ClusterDeployment {
 	var cd hivev1.ClusterDeployment
 	if err := GetFileData("cluster-deployment.yaml", &cd); err != nil {
-		fmt.Println(err.Error())
+		logrus.Println(err.Error())
 		os.Exit(1)
 	}
 
@@ -36,7 +36,7 @@ func getClusterDeployment() hivev1.ClusterDeployment {
 func GetAgentClusterInstall() hiveext.AgentClusterInstall {
 	var aci hiveext.AgentClusterInstall
 	if err := GetFileData("agent-cluster-install.yaml", &aci); err != nil {
-		fmt.Println(err.Error())
+		logrus.Println(err.Error())
 		os.Exit(1)
 	}
 

--- a/pkg/manifests/infraenv.go
+++ b/pkg/manifests/infraenv.go
@@ -1,7 +1,6 @@
 package manifests
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -9,12 +8,13 @@ import (
 	"github.com/go-openapi/swag"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 )
 
 func getInfraEnv() aiv1beta1.InfraEnv {
 	var infraEnv aiv1beta1.InfraEnv
 	if err := GetFileData("infraenv.yaml", &infraEnv); err != nil {
-		fmt.Println(err.Error())
+		logrus.Println(err.Error())
 		os.Exit(1)
 	}
 

--- a/pkg/manifests/nmstateconfig.go
+++ b/pkg/manifests/nmstateconfig.go
@@ -76,9 +76,7 @@ func validateNMStateConfigAndInfraEnv(nmStateConfig aiv1beta1.NMStateConfig, inf
 func buildMacInterfaceMap(nmStateConfig aiv1beta1.NMStateConfig) models.MacInterfaceMap {
 	macInterfaceMap := make(models.MacInterfaceMap, 0, len(nmStateConfig.Spec.Interfaces))
 	for _, cfg := range nmStateConfig.Spec.Interfaces {
-		// ToDo: Use logging
-		// fmt.Println("adding MAC interface map to host static network config - Name: %s, MacAddress: %s ,",
-		// 	cfg.Name, cfg.MacAddress)
+		logrus.Println("adding MAC interface map to host static network config - Name: ", cfg.Name, " MacAddress:", cfg.MacAddress)
 		macInterfaceMap = append(macInterfaceMap, &models.MacInterfaceMapItems0{
 			MacAddress:     cfg.MacAddress,
 			LogicalNicName: cfg.Name,


### PR DESCRIPTION
Instead of `fmt.Errorf`, use a logging library to log the errors and debug information. Use `github.com/sirupsen/logrus v1.8.1` logging library same as in `Openshift installer`.

Ref: https://issues.redhat.com/browse/AGENT-66