### PR TITLE
Fix format specifiers leading to makefile error

### DIFF
--- a/pkg/imagebuilder/content.go
+++ b/pkg/imagebuilder/content.go
@@ -51,17 +51,17 @@ func New() *ConfigBuilder {
 	clusterParams := manifests.CreateClusterParams()
 	clusterJSON, err := json.Marshal(clusterParams)
 	if err != nil {
-		logrus.Errorf("Error marshalling cluster params into json: %w", err)
+		logrus.Errorf("Error marshalling cluster params into json: %v", err)
 	}
 
 	infraEnvParams, err := manifests.CreateInfraEnvParams()
 	if err != nil {
-		logrus.Errorf("Error building infra env params: %w", err)
+		logrus.Errorf("Error building infra env params: %v", err)
 	}
 
 	infraEnvJSON, err := json.Marshal(infraEnvParams)
 	if err != nil {
-		logrus.Errorf("Error marshal infra env params into json: %w", err)
+		logrus.Errorf("Error marshal infra env params into json: %v", err)
 	}
 
 	aci := manifests.GetAgentClusterInstall()


### PR DESCRIPTION
The incorrect format specifier in `pkg/imagebuilder/content.go` was causing the makefile target `unit-test` to fail with `make: *** [Makefile:26: unit-test] Error 2`. This PR fixes the format specifier.

Before this fix:
```
go test -v ./pkg/imagebuilder/...
# github.com/openshift-agent-team/fleeting/pkg/imagebuilder
pkg/imagebuilder/content.go:54:3: Errorf call has error-wrapping directive %w, which is only supported by Errorf
pkg/imagebuilder/content.go:59:3: Errorf call has error-wrapping directive %w, which is only supported by Errorf
pkg/imagebuilder/content.go:64:3: Errorf call has error-wrapping directive %w, which is only supported by Errorf
make: *** [Makefile:26: unit-test] Error 2
```
After this fix:
The above error is resolved.

